### PR TITLE
Create a debian package for server deployment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,7 +1299,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "peach-dyndns-host"
+name = "peach-dyndns-server"
 version = "0.1.0"
 dependencies = [
  "clap-log-flag",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,7 @@ maintainer-scripts="debian"
 systemd-units = { unit-name = "peach-dyndns-server" }
 assets = [
     ["target/release/peach-dyndns-server", "usr/bin/", "755"],
+    ["debian/reloadbind", "usr/bin/", "755"],
+    ["debian/bindctl", "/etc/sudoers.d/bindctl", "655"],
+    ["templates/*", "/srv/peachcloud/peach-dyndns-server/prod-peach-dyndns/templates/", "644"],
 ]
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "peach-dyndns-host"
+name = "peach-dyndns-server"
 version = "0.1.0"
 authors = ["Michael Williams <michael.williams@enspiral.com>", "Max Fowler <notplants@mfowler.info>"]
 edition = "2018"
@@ -24,6 +24,13 @@ dotenv = "0.15.0"
 tera = "1"
 regex = "1"
 
-[[bin]]
-name = "main"
-path = "src/main.rs"
+[package.metadata.deb]
+depends = "$auto"
+extended-description = """\
+peach-dyndns is an http API to create dynamic-dns configurations for bind9."""
+maintainer-scripts="debian"
+systemd-units = { unit-name = "peach-dyndns-server" }
+assets = [
+    ["target/release/peach-dyndns-server", "usr/bin/", "755"],
+]
+

--- a/README.md
+++ b/README.md
@@ -4,23 +4,31 @@ a dynamic DNS server to host the names of guests with changing IP addresses
 by providing an http API for updating bind9 configurations. 
 
 
-## setup 
+## Setup
 
 The code in this repo assumes the existence of an installed and running bind9 server on the same 
 server as is running peach-dyndns-server. Documentation for setting up bind9 can be found [here](docs/setup-bind-for-peach-dyndns.md).
 
 The peach-dyndns-server code can be compiled with
 ```
-cargo build --release
+cargo deb; sudo dpkg -i target/debian/peach-dyndns-server_0.1.0_amd64.deb
 ```
 
-## run
+## Development
 
 ```
 sudo su peach-dyndns; ./target/release/main -vv
 ```
 
-## test
+## Prod Deployment 
+
+prod is deployed to /srv/peachcloud/peach-dyndns-server/prod-peach-dyndns
+
+## Staging Deployment 
+
+staging is deployed to /srv/peachcloud/peach-dyndns-server/dev-peach-dyndns
+
+## Test
 
 test peach-dyndns server is running,
 ```

--- a/Rocket.toml
+++ b/Rocket.toml
@@ -1,0 +1,3 @@
+[default]
+template_dir = "templates/"
+port = 3001

--- a/debian/bindctl
+++ b/debian/bindctl
@@ -1,0 +1,12 @@
+#
+# Allow peach-dyndns to reload bind as sudo
+#
+
+# User alias for bind-ctl which can reload bind
+User_Alias  BIND_CTRL = peach-dyndns
+
+# Command alias for reboot and shutdown
+Cmnd_Alias  RELOADBIND = /usr/bin/reloadbind
+
+# Allow BIND_CTRL users to execute RELOADBIND command without password
+BIND_CTRL  ALL=(ALL) NOPASSWD: RELOADBIND

--- a/debian/peach-dyndns-server.service
+++ b/debian/peach-dyndns-server.service
@@ -6,7 +6,9 @@ Type=simple
 User=peach-dyndns
 Group=bind
 Environment="RUST_LOG=info"
-ExecStart=/usr/bin/peach-dyndns-server
+Environment="ROCKET_PORT=3002"
+WorkingDirectory=/srv/peachcloud/peach-dyndns-server/prod-peach-dyndns
+ExecStart=/usr/bin/peach-dyndns-server -vv
 Restart=always
 
 [Install]

--- a/debian/peach-dyndns-server.service
+++ b/debian/peach-dyndns-server.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=An http API to create dynamic-dns configurations for bind9.
+
+[Service]
+Type=simple
+User=peach-dyndns
+Group=bind
+Environment="RUST_LOG=info"
+ExecStart=/usr/bin/peach-dyndns-server
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# create user which peach-dyndns-server runs as
+adduser --quiet --system peach-dyndns
+
+# add user to bind group
+usermod -a -G bind peach-dyndns
+
+# set permissions
+chown peach-dyndns /usr/bin/peach-dyndns-server
+chown peach-dyndns /usr/bin/reloadbind
+
+# cargo deb automatically replaces this token below, see https://github.com/mmstick/cargo-deb/blob/master/systemd.md
+#DEBHELPER#

--- a/debian/reloadbind
+++ b/debian/reloadbind
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+/bin/systemctl reload bind9

--- a/deploy_prod.sh
+++ b/deploy_prod.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# this script rebuilds the peach-dyndns-server for prod deployment using the dev folder as the source repo
+cd /srv/peachcloud/peach-dyndns-server/dev-peach-dyndns
+cargo deb
+sudo dpkg -i target/debian/peach-dyndns-server_0.1.0_amd64.deb
+sudo systemctl restart peach-dyndns-server
+sudo systemctl restart nginx

--- a/src/generate_zone.rs
+++ b/src/generate_zone.rs
@@ -131,7 +131,7 @@ pub fn generate_zone(full_domain: &str) -> Result<String, PeachDynError> {
     // we use the /etc/sudoers.d/bindctl to allow peach-dyndns user to restart bind as sudo without entering a password
     // using a binary at /bin/reloadbind which runs 'systemctl reload bind9'
     let status = Command::new("sudo")
-        .arg("/bin/reloadbind")
+        .arg("/usr/bin/reloadbind")
         .status().expect("error restarting bind9");
     if !status.success() {
         return Err(PeachDynError::BindConfigurationError("There was an error in the bind configuration".to_string()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,7 @@
 extern crate rocket;
 
 use crate::routes::{index, register_domain, check_available};
-use rocket::Config;
-use rocket::figment::{Figment, Profile, providers::{Format, Toml, Serialized, Env}};
+use rocket::figment::{Figment, providers::{Format, Toml, Env}};
 
 mod cli;
 mod routes;
@@ -18,9 +17,10 @@ async fn main() {
     let _args = cli::args().expect("error parsing args");
 
     // the following config says to use all default rocket configs
-    // and then override them with any configs specified in Rocket.toml
+    // and then override them with any configs specified in Rocket.toml if found
+    // and then override with any configs specified as env variables prefixed with APP_
     let config = Figment::from(rocket::Config::default())
-      .merge(Toml::file("Rocket.toml").nested());
+      .merge(Toml::file("Rocket.toml").nested()).merge(Env::prefixed("ROCKET_").global());
 
     let rocket_result = rocket::custom(config)
         .mount("/", routes![index, register_domain, check_available])

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@
 extern crate rocket;
 
 use crate::routes::{index, register_domain, check_available};
+use rocket::Config;
+use rocket::figment::{Figment, Profile, providers::{Format, Toml, Serialized, Env}};
 
 mod cli;
 mod routes;
@@ -15,7 +17,12 @@ mod generate_zone;
 async fn main() {
     let _args = cli::args().expect("error parsing args");
 
-    let rocket_result = rocket::build()
+    // the following config says to use all default rocket configs
+    // and then override them with any configs specified in Rocket.toml
+    let config = Figment::from(rocket::Config::default())
+      .merge(Toml::file("Rocket.toml").nested());
+
+    let rocket_result = rocket::custom(config)
         .mount("/", routes![index, register_domain, check_available])
         .launch()
         .await;


### PR DESCRIPTION
This PR uses cargo-deb to deploy the peach-dyndns-server service as a live server on prod using systemd. 

In the future, we may want to look into using ansible or a different configuration software for production if we want to make things more robust (e.g. staging and production server), but this is tested and working, and on the plus side has parity with our other repos.

On the peach-vps there is a repo `/srv/peachcloud/peach-dyndns-server/dev-peach-dyndns` which contains the source code. 

In that repo you can build the .deb using cargo-deb. When you install the cargo-deb, it uses, `/srv/peachcloud/peach-dyndns-server/prod-peach-dyndns` as a working directory which the prod server runs out of. 

A couple other interesting things. 
- I used the sudoers.d pattern you used in peach-network, to allow peach-dyndns user to reload bind using sudo without a password. Although I think the way I've currently done this may be not a best practice, as I wrote a script /bin/reloadbind which is the command that it has special sudo permission to run... I guess I need to ensure that peach-dydns can run /bin/reloadbind but can't edit it... otherwise I think it could just edit the file and then essentially that would be a loophole to escalate its sudo privilges to run anything as sudo?  But maybe if I ensure /bin/reloadbind is only editable by root, then its ok. 
- nginx proxying is still handled separately from this, manually. the cargo-deb just makes sure the server is running. 